### PR TITLE
Replace Lato with Open Sans to fix Czech diacritics

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -76,7 +76,7 @@
 	<!-- iOS Safari -->
 	<meta name="apple-mobile-web-app-status-bar-style" content="#263959">
 	<!-- Google Fonts -->
-	<link href="https://fonts.googleapis.com/css?family=PT+Serif:400,700|Lato:300,400,700&display=swap" rel="stylesheet">
+	<link href="https://fonts.googleapis.com/css2?family=PT+Serif:wght@400;700&family=Open+Sans:wght@300;400;700&display=swap" rel="stylesheet">
 	<!-- Font Awesome -->
 	<link rel="stylesheet" href="{{ "/assets/fonts/font-awesome/css/font-awesome.min.css" | prepend: site.baseurl }}">
 	<!-- Styles -->

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -773,7 +773,7 @@ html {
 }
 
 body {
-  font-family: 'Lato', sans-serif;
+  font-family: 'Open Sans', sans-serif;
   color: #515151;
   background-color: #fbfbfb;
   margin: 0;

--- a/assets/css/scss/main.scss
+++ b/assets/css/scss/main.scss
@@ -11,7 +11,7 @@ html {
 }
 
 body {
-  font-family: 'Lato', sans-serif;
+  font-family: 'Open Sans', sans-serif;
   color: $body-color;
   background-color: #fbfbfb;
   margin: 0;


### PR DESCRIPTION
## Summary
- Lato font has rendering issues with Czech diacritics (č, ě, ř, š, ž etc.)
- Replaced Lato with Open Sans — visually the closest alternative with full latin-ext support
- Upgraded Google Fonts API from v1 to v2

## Changed files
- `_includes/head.html` — new Google Fonts link
- `assets/css/main.css` — `font-family: 'Open Sans'`
- `assets/css/scss/main.scss` — `font-family: 'Open Sans'`